### PR TITLE
fix for windows by adding / in require

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ function Angular2ConventionsLoader(source, sourcemap) {
         }
       }
       if (_hasHtmlFile) {
-        metadata = 'template: require(".' + lastFileName + htmlExtension + '"),\n' + metadata;
+        metadata = 'template: require("./' + lastFileName + htmlExtension + '"),\n' + metadata;
       }
     }
     if (!(/styles\s*:(\s*\[[\s\S]*?\])/g.test(metadata))) {
@@ -160,7 +160,7 @@ function Angular2ConventionsLoader(source, sourcemap) {
       }
 
       if (_hasCssFile) {
-        metadata = 'styles: [require(".' + lastFileName + cssExtension + '")],\n' + metadata;
+        metadata = 'styles: [require("./' + lastFileName + cssExtension + '")],\n' + metadata;
       }
     }
     // strip moduleId


### PR DESCRIPTION
Adding ./ before html and css file names will fix the issue on windows (app.html and app.css not found)